### PR TITLE
Fix bug with web3 versioning in package.json

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -9,7 +9,7 @@
   "author": "onenetwork",
   "license": "Apache-2.0",
   "dependencies": {
-    "web3": "^1.0.0-beta.28"
+    "web3": "1.0.0-beta.28"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
The "^1.0.0-beta.28" version is causing npm to download and use
"1.0.0-beta2" instead, so this change ensures we pull the correct version.