### PR TITLE
Fix web3 import in JS client

### DIFF
--- a/js/backchain-client.js
+++ b/js/backchain-client.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var fs = require('fs');
-var Web3 = require('Web3');
+var Web3 = require('web3');
 
 /**
  * Constructs a new client
@@ -11,12 +11,12 @@ module.exports = function(config) {
   if (config.blockchain != 'eth') {
     throw new Error('blockchain not supported: ' + config.blockchain);
   }
-  
+
   var web3 = new Web3(new Web3.providers.HttpProvider(config.url));
-  
+
   // Warning - this abi must be updated any time Backchain.sol changes
   var abi = [{"type":"function","payable":false,"outputs":[{"type":"uint256","name":""}],"name":"hashCount","inputs":[],"constant":true},{"type":"function","payable":false,"outputs":[{"type":"bytes32","name":""}],"name":"getHash","inputs":[{"type":"uint256","name":"index"}],"constant":true},{"type":"function","payable":false,"outputs":[{"type":"bool","name":""}],"name":"verify","inputs":[{"type":"bytes32","name":"hash"}],"constant":true},{"type":"function","payable":false,"outputs":[],"name":"post","inputs":[{"type":"bytes32","name":"hash"}],"constant":false},{"type":"function","payable":false,"outputs":[{"type":"address","name":""}],"name":"orchestrator","inputs":[],"constant":true},{"type":"function","payable":false,"outputs":[{"type":"bool","name":""}],"name":"hashMapping","inputs":[{"type":"bytes32","name":""}],"constant":true},{"type":"constructor","payable":false,"inputs":[]}];
-  
+
   config.fromAddress = web3.eth.accounts.privateKeyToAccount(config.privateKey).address;
   var contract = new web3.eth.Contract(abi, config.contractAddress, {
     from: config.fromAddress
@@ -24,8 +24,8 @@ module.exports = function(config) {
   return {
     config: config,
     hashCount: function() {
-      return contract.methods.hashCount().call().then(function(result) { 
-        return Promise.resolve(parseInt(result)) 
+      return contract.methods.hashCount().call().then(function(result) {
+        return Promise.resolve(parseInt(result))
       });
     },
     post: function(hash) {

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@onenetwork/one-backchain-client",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -38,6 +38,16 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "asn1.js": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
+      "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+      "requires": {
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -170,12 +180,68 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
+    "browserify-aes": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+      "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+      "requires": {
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "browserify-cipher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+      "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+      "requires": {
+        "browserify-aes": "1.1.1",
+        "browserify-des": "1.0.0",
+        "evp_bytestokey": "1.0.3"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+      "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+      "requires": {
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3"
+      }
+    },
+    "browserify-rsa": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.6"
+      }
+    },
     "browserify-sha3": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
       "integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
       "requires": {
         "js-sha3": "0.3.1"
+      }
+    },
+    "browserify-sign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.0"
       }
     },
     "buffer": {
@@ -199,6 +265,11 @@
       "requires": {
         "tape": "3.6.1"
       }
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "bytes": {
       "version": "3.0.0",
@@ -255,7 +326,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -294,6 +365,15 @@
       "requires": {
         "object-assign": "4.1.1",
         "vary": "1.1.2"
+      }
+    },
+    "create-ecdh": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+      "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.0"
       }
     },
     "create-hash": {
@@ -338,6 +418,24 @@
         }
       }
     },
+    "crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "requires": {
+        "browserify-cipher": "1.0.0",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.0",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "diffie-hellman": "5.0.2",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.14",
+        "public-encrypt": "4.0.0",
+        "randombytes": "2.0.6",
+        "randomfill": "1.0.3"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -349,7 +447,7 @@
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -447,7 +545,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
         "type-detect": "4.0.3"
@@ -473,6 +571,15 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
       "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
     },
+    "des.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
+    },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -481,8 +588,18 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
       "dev": true
+    },
+    "diffie-hellman": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+      "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.6"
+      }
     },
     "dom-walk": {
       "version": "0.1.1",
@@ -585,6 +702,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
       "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "requires": {
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.1"
+      }
     },
     "express": {
       "version": "4.16.2",
@@ -781,7 +907,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -834,7 +960,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
       "dev": true
     },
     "har-schema": {
@@ -1124,6 +1250,26 @@
         "pify": "2.3.0"
       }
     },
+    "md5.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+      "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+      "requires": {
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "hash-base": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+          "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+          "requires": {
+            "inherits": "2.0.3",
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -1138,6 +1284,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "requires": {
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
+      }
     },
     "mime": {
       "version": "1.4.1",
@@ -1183,7 +1338,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -1340,6 +1495,18 @@
         "p-finally": "1.0.0"
       }
     },
+    "parse-asn1": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+      "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+      "requires": {
+        "asn1.js": "4.9.2",
+        "browserify-aes": "1.1.1",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.14"
+      }
+    },
     "parse-headers": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
@@ -1434,6 +1601,18 @@
         "ipaddr.js": "1.5.2"
       }
     },
+    "public-encrypt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+      "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "parse-asn1": "5.1.0",
+        "randombytes": "2.0.6"
+      }
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -1450,6 +1629,23 @@
       "integrity": "sha1-fbBmZCCAS6qSrp8miWKFWnYUPfs=",
       "requires": {
         "strict-uri-encode": "1.1.0"
+      }
+    },
+    "randombytes": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+      "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+      "requires": {
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.1"
       }
     },
     "randomhex": {
@@ -1749,28 +1945,10 @@
     "supports-color": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
       "dev": true,
       "requires": {
         "has-flag": "2.0.0"
-      }
-    },
-    "swarm-js": {
-      "version": "0.1.35",
-      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.35.tgz",
-      "integrity": "sha512-fwVjz/RoRV8/HoZHbbYjKHu+gCiXHrtUwbw0gxc0E1yQPjV5cEXzbCblbBJPzezcBEAbLDYPdMXkclbsW7aGhw==",
-      "requires": {
-        "buffer": "5.0.8",
-        "decompress": "4.2.0",
-        "fs-extra": "2.1.2",
-        "fs-promise": "2.0.3",
-        "got": "7.1.0",
-        "mime-types": "2.1.17",
-        "mkdirp-promise": "5.0.1",
-        "mock-fs": "4.4.1",
-        "setimmediate": "1.0.5",
-        "tar.gz": "1.0.5",
-        "xhr-request-promise": "0.1.2"
       }
     },
     "tape": {
@@ -2016,287 +2194,323 @@
       }
     },
     "web3": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.23.tgz",
-      "integrity": "sha1-0ikrUH80vDbUh5QJjXQGan9RjPg=",
+      "version": "1.0.0-beta.28",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.28.tgz",
+      "integrity": "sha1-uvNF4QWfoPRQGLrFIN3WpdtJxpU=",
       "requires": {
-        "web3-bzz": "1.0.0-beta.22",
-        "web3-core": "1.0.0-beta.23",
-        "web3-eth": "1.0.0-beta.23",
-        "web3-eth-personal": "1.0.0-beta.23",
-        "web3-net": "1.0.0-beta.23",
-        "web3-shh": "1.0.0-beta.23",
-        "web3-utils": "1.0.0-beta.23"
-      }
-    },
-    "web3-bzz": {
-      "version": "1.0.0-beta.22",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.22.tgz",
-      "integrity": "sha1-jrLbNKlEiDnpwMb1pI5n5m4jopQ=",
-      "requires": {
-        "got": "7.1.0",
-        "swarm-js": "0.1.35",
-        "underscore": "1.8.3"
-      }
-    },
-    "web3-core": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.23.tgz",
-      "integrity": "sha1-zsimg2EIn1lmjvsM85C3N+lV/VE=",
-      "requires": {
-        "web3-core-helpers": "1.0.0-beta.23",
-        "web3-core-method": "1.0.0-beta.23",
-        "web3-core-requestmanager": "1.0.0-beta.23",
-        "web3-utils": "1.0.0-beta.23"
-      }
-    },
-    "web3-core-helpers": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.23.tgz",
-      "integrity": "sha1-XlxIo7pqE+wMitHqY05oC6hNSt8=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-eth-iban": "1.0.0-beta.23",
-        "web3-utils": "1.0.0-beta.23"
-      }
-    },
-    "web3-core-method": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.23.tgz",
-      "integrity": "sha1-xPvNAJIGLPv57mWC4+41O8qYGMc=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.23",
-        "web3-core-promievent": "1.0.0-beta.22",
-        "web3-core-subscriptions": "1.0.0-beta.23",
-        "web3-utils": "1.0.0-beta.23"
-      }
-    },
-    "web3-core-promievent": {
-      "version": "1.0.0-beta.22",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.22.tgz",
-      "integrity": "sha1-qGLxW+o4c0qcOH9jwi568eC4cYg=",
-      "requires": {
-        "bluebird": "3.3.1",
-        "eventemitter3": "1.1.1"
+        "web3-bzz": "1.0.0-beta.28",
+        "web3-core": "1.0.0-beta.28",
+        "web3-eth": "1.0.0-beta.28",
+        "web3-eth-personal": "1.0.0-beta.28",
+        "web3-net": "1.0.0-beta.28",
+        "web3-shh": "1.0.0-beta.28",
+        "web3-utils": "1.0.0-beta.28"
       },
       "dependencies": {
         "bluebird": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
-          "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
-        }
-      }
-    },
-    "web3-core-requestmanager": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.23.tgz",
-      "integrity": "sha1-OMONuUZ0uCJhDDgeAfsNT/J1/H0=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.23",
-        "web3-providers-http": "1.0.0-beta.23",
-        "web3-providers-ipc": "1.0.0-beta.23",
-        "web3-providers-ws": "1.0.0-beta.23"
-      }
-    },
-    "web3-core-subscriptions": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.23.tgz",
-      "integrity": "sha1-Ojrj/wPx43HcuaL9pP/gkCnocEc=",
-      "requires": {
-        "eventemitter3": "1.1.1",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.23"
-      }
-    },
-    "web3-eth": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.23.tgz",
-      "integrity": "sha1-LmelMbykoT8j4PH0Xw2UFgxyVjo=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.23",
-        "web3-core-helpers": "1.0.0-beta.23",
-        "web3-core-method": "1.0.0-beta.23",
-        "web3-core-subscriptions": "1.0.0-beta.23",
-        "web3-eth-abi": "1.0.0-beta.23",
-        "web3-eth-accounts": "1.0.0-beta.23",
-        "web3-eth-contract": "1.0.0-beta.23",
-        "web3-eth-iban": "1.0.0-beta.23",
-        "web3-eth-personal": "1.0.0-beta.23",
-        "web3-net": "1.0.0-beta.23",
-        "web3-utils": "1.0.0-beta.23"
-      }
-    },
-    "web3-eth-abi": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.23.tgz",
-      "integrity": "sha1-yPLrQw0Egk1Zk0W4j7LbnEb0CA4=",
-      "requires": {
-        "bn.js": "4.11.6",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.23",
-        "web3-utils": "1.0.0-beta.23"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        }
-      }
-    },
-    "web3-eth-accounts": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.23.tgz",
-      "integrity": "sha1-Gli4LhS+wlkFU/G/3JeFikX5wUg=",
-      "requires": {
-        "bluebird": "3.3.1",
-        "eth-lib": "0.1.27",
-        "scrypt.js": "0.2.0",
-        "underscore": "1.8.3",
-        "uuid": "2.0.1",
-        "web3-core": "1.0.0-beta.23",
-        "web3-core-helpers": "1.0.0-beta.23",
-        "web3-core-method": "1.0.0-beta.23",
-        "web3-utils": "1.0.0-beta.23"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
-          "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
         },
-        "uuid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-        }
-      }
-    },
-    "web3-eth-contract": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.23.tgz",
-      "integrity": "sha1-2ggvWWDW1srPRDsGXFKvo+fQ7aQ=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.23",
-        "web3-core-helpers": "1.0.0-beta.23",
-        "web3-core-method": "1.0.0-beta.23",
-        "web3-core-promievent": "1.0.0-beta.22",
-        "web3-core-subscriptions": "1.0.0-beta.23",
-        "web3-eth-abi": "1.0.0-beta.23",
-        "web3-utils": "1.0.0-beta.23"
-      }
-    },
-    "web3-eth-iban": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.23.tgz",
-      "integrity": "sha1-sq46/6/olNuGtlc1zDj9jZvntdI=",
-      "requires": {
-        "bn.js": "4.11.8",
-        "web3-utils": "1.0.0-beta.23"
-      }
-    },
-    "web3-eth-personal": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.23.tgz",
-      "integrity": "sha1-vgIu9exkKTbBILgAnv09lmiu+r0=",
-      "requires": {
-        "web3-core": "1.0.0-beta.23",
-        "web3-core-helpers": "1.0.0-beta.23",
-        "web3-core-method": "1.0.0-beta.23",
-        "web3-net": "1.0.0-beta.23",
-        "web3-utils": "1.0.0-beta.23"
-      }
-    },
-    "web3-net": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.23.tgz",
-      "integrity": "sha1-EcJcsvlOcks4s8ScT/fYDpdRcWI=",
-      "requires": {
-        "web3-core": "1.0.0-beta.23",
-        "web3-core-method": "1.0.0-beta.23",
-        "web3-utils": "1.0.0-beta.23"
-      }
-    },
-    "web3-providers-http": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.23.tgz",
-      "integrity": "sha1-X61ZZ3DvsV4YkpxrguO14uvk9uk=",
-      "requires": {
-        "web3-core-helpers": "1.0.0-beta.23",
-        "xhr2": "0.1.4"
-      }
-    },
-    "web3-providers-ipc": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.23.tgz",
-      "integrity": "sha1-/xQfQm0rqllUCeB23fadysHWvKQ=",
-      "requires": {
-        "oboe": "2.1.3",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.23"
-      }
-    },
-    "web3-providers-ws": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.23.tgz",
-      "integrity": "sha1-l5NPZ2fIwLT7QS3jyrer/QGMFsA=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.23",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
-      }
-    },
-    "web3-shh": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.23.tgz",
-      "integrity": "sha1-LyexQI1M8TQSl+LwyHuL+yVE8Sk=",
-      "requires": {
-        "web3-core": "1.0.0-beta.23",
-        "web3-core-method": "1.0.0-beta.23",
-        "web3-core-subscriptions": "1.0.0-beta.23",
-        "web3-net": "1.0.0-beta.23"
-      }
-    },
-    "web3-utils": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.23.tgz",
-      "integrity": "sha1-N70dd4VJgwpw1OV6hhHG4YPRh8g=",
-      "requires": {
-        "bn.js": "4.11.6",
-        "eth-lib": "0.1.27",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randomhex": "0.1.5",
-        "underscore": "1.8.3",
-        "utf8": "2.1.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        }
-      }
-    },
-    "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
-      "requires": {
-        "debug": "2.6.9",
-        "nan": "2.7.0",
-        "typedarray-to-buffer": "3.1.2",
-        "yaeti": "0.0.6"
-      },
-      "dependencies": {
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "swarm-js": {
+          "version": "0.1.37",
+          "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.37.tgz",
+          "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
+          "requires": {
+            "bluebird": "3.5.1",
+            "buffer": "5.0.8",
+            "decompress": "4.2.0",
+            "eth-lib": "0.1.27",
+            "fs-extra": "2.1.2",
+            "fs-promise": "2.0.3",
+            "got": "7.1.0",
+            "mime-types": "2.1.17",
+            "mkdirp-promise": "5.0.1",
+            "mock-fs": "4.4.1",
+            "setimmediate": "1.0.5",
+            "tar.gz": "1.0.5",
+            "xhr-request-promise": "0.1.2"
+          }
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3-bzz": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.28.tgz",
+          "integrity": "sha1-YyApNFf2U7FYa9JqodCQhUp+U5U=",
+          "requires": {
+            "got": "7.1.0",
+            "swarm-js": "0.1.37",
+            "underscore": "1.8.3"
+          }
+        },
+        "web3-core": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.28.tgz",
+          "integrity": "sha1-EhUapKy0cFDQL0Fkth5hAr/IneY=",
+          "requires": {
+            "web3-core-helpers": "1.0.0-beta.28",
+            "web3-core-method": "1.0.0-beta.28",
+            "web3-core-requestmanager": "1.0.0-beta.28",
+            "web3-utils": "1.0.0-beta.28"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.28.tgz",
+          "integrity": "sha1-hMmwQFgjrnbEvBg0bq0UJzvhnkA=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-eth-iban": "1.0.0-beta.28",
+            "web3-utils": "1.0.0-beta.28"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.28.tgz",
+          "integrity": "sha1-Pb+GqnZXSdY1ACH0W4lN9sAV0x0=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.28",
+            "web3-core-promievent": "1.0.0-beta.28",
+            "web3-core-subscriptions": "1.0.0-beta.28",
+            "web3-utils": "1.0.0-beta.28"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.28.tgz",
+          "integrity": "sha1-nGHFAJhRI7Z8eGCI53i/1/8jiOQ=",
+          "requires": {
+            "bluebird": "3.3.1",
+            "eventemitter3": "1.1.1"
+          },
+          "dependencies": {
+            "bluebird": {
+              "version": "3.3.1",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
+              "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
+            }
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.28.tgz",
+          "integrity": "sha1-DLdHLLuUqVFY8vPbRWR0UmGWuSQ=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.28",
+            "web3-providers-http": "1.0.0-beta.28",
+            "web3-providers-ipc": "1.0.0-beta.28",
+            "web3-providers-ws": "1.0.0-beta.28"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.28.tgz",
+          "integrity": "sha1-yJgTOAmQb4XYSbE8cT8SJTyqRsc=",
+          "requires": {
+            "eventemitter3": "1.1.1",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.28"
+          }
+        },
+        "web3-eth": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.28.tgz",
+          "integrity": "sha1-qOwlimeZWPWfWOiqmY8Yqp2W0ZE=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core": "1.0.0-beta.28",
+            "web3-core-helpers": "1.0.0-beta.28",
+            "web3-core-method": "1.0.0-beta.28",
+            "web3-core-subscriptions": "1.0.0-beta.28",
+            "web3-eth-abi": "1.0.0-beta.28",
+            "web3-eth-accounts": "1.0.0-beta.28",
+            "web3-eth-contract": "1.0.0-beta.28",
+            "web3-eth-iban": "1.0.0-beta.28",
+            "web3-eth-personal": "1.0.0-beta.28",
+            "web3-net": "1.0.0-beta.28",
+            "web3-utils": "1.0.0-beta.28"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.28.tgz",
+          "integrity": "sha1-lqwiXtnqkDBfhde3eMbsXPZINZQ=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.28",
+            "web3-utils": "1.0.0-beta.28"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+            }
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.28.tgz",
+          "integrity": "sha1-J9W1X0YSgnWNuhG/NQiWb56vM+o=",
+          "requires": {
+            "bluebird": "3.3.1",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "scrypt.js": "0.2.0",
+            "underscore": "1.8.3",
+            "uuid": "2.0.1",
+            "web3-core": "1.0.0-beta.28",
+            "web3-core-helpers": "1.0.0-beta.28",
+            "web3-core-method": "1.0.0-beta.28",
+            "web3-utils": "1.0.0-beta.28"
+          },
+          "dependencies": {
+            "bluebird": {
+              "version": "3.3.1",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
+              "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0",
+                "xhr-request-promise": "0.1.2"
+              }
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.28.tgz",
+          "integrity": "sha1-oX85FPYdLLEGhZyhi6XsQcS+ocU=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core": "1.0.0-beta.28",
+            "web3-core-helpers": "1.0.0-beta.28",
+            "web3-core-method": "1.0.0-beta.28",
+            "web3-core-promievent": "1.0.0-beta.28",
+            "web3-core-subscriptions": "1.0.0-beta.28",
+            "web3-eth-abi": "1.0.0-beta.28",
+            "web3-utils": "1.0.0-beta.28"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.28.tgz",
+          "integrity": "sha1-Dt5pzcYn7AHScFq54Jwbvdqt3gI=",
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.0.0-beta.28"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.28.tgz",
+          "integrity": "sha1-cwEFBzACSRm6SG4uSYCEpHrCN8U=",
+          "requires": {
+            "web3-core": "1.0.0-beta.28",
+            "web3-core-helpers": "1.0.0-beta.28",
+            "web3-core-method": "1.0.0-beta.28",
+            "web3-net": "1.0.0-beta.28",
+            "web3-utils": "1.0.0-beta.28"
+          }
+        },
+        "web3-net": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.28.tgz",
+          "integrity": "sha1-4uYlsScstHYlnaZGFPVeshMzZR8=",
+          "requires": {
+            "web3-core": "1.0.0-beta.28",
+            "web3-core-method": "1.0.0-beta.28",
+            "web3-utils": "1.0.0-beta.28"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.28.tgz",
+          "integrity": "sha1-/7RO+ZWIYAmyx77Z+iOsXblXZAA=",
+          "requires": {
+            "web3-core-helpers": "1.0.0-beta.28",
+            "xhr2": "0.1.4"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.28.tgz",
+          "integrity": "sha1-Mqo5t8g8M7SK3txUxvHVcXb5yNA=",
+          "requires": {
+            "oboe": "2.1.3",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.28"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.28.tgz",
+          "integrity": "sha1-K8x8+2XV5EO60om9FNA81B/aPM0=",
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.28",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
+          }
+        },
+        "web3-shh": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.28.tgz",
+          "integrity": "sha1-S3GLIgf13u3o5uJ2y79AKSY7m9I=",
+          "requires": {
+            "web3-core": "1.0.0-beta.28",
+            "web3-core-method": "1.0.0-beta.28",
+            "web3-core-subscriptions": "1.0.0-beta.28",
+            "web3-net": "1.0.0-beta.28"
+          }
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.28",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.28.tgz",
+          "integrity": "sha1-RNSEVPuzJqYPlAnIgvAnuHQPDuY=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+            }
+          }
+        },
+        "websocket": {
+          "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
+          "requires": {
+            "debug": "2.6.9",
+            "nan": "2.7.0",
+            "typedarray-to-buffer": "3.1.2",
+            "yaeti": "0.0.6"
           }
         }
       }

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onenetwork/one-backchain-client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Sample client for ONE's Backchain",
   "main": "backchain-client.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes the casing on the web3 import in the JS client from `require('Web3')` to `require('web3')`, which was causing issues when building inside of Docker. It also updates the web3 dependency within `package-lock.json` to match `package.json`.